### PR TITLE
Add headerHeight override for lrStickyHeight to stStickyHeight

### DIFF
--- a/stStickyHeader.js
+++ b/stStickyHeader.js
@@ -5,7 +5,7 @@
       return {
         require: '^?stTable',
         link: function (scope, element, attr, ctrl) {
-          var stickyHeader = lrStickyHeader(element[0]);
+          var stickyHeader = lrStickyHeader(element[0], {headerHeight: attr.stStickyHeaderTop});
           scope.$on('$destroy', function () {
             stickyHeader.clean();
           });


### PR DESCRIPTION
I created a pull request in lrStickyHeight which allows the user to set
an offset height: https://github.com/lorenzofox3/lrStickyHeader/pull/5.
This extends that functionality into the angular wrapper.
